### PR TITLE
feat: Webhook Idempotency Guard (WBHK-0002)

### DIFF
--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Header, HTTPException, Request, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.database import get_db
+from app.middleware.idempotency import IdempotencyGuard
 from app.models.schemas import WebhookResponse
 from app.services.stripe_service import verify_webhook_signature, extract_customer_data, is_first_subscription
 from app.services.customer_service import get_customer_by_stripe_id
@@ -26,6 +27,12 @@ async def stripe_webhook(
     if event is None:
         raise HTTPException(status_code=400, detail="Invalid webhook signature")
 
+    # Idempotency check: skip if this event was already processed
+    guard = IdempotencyGuard(db)
+    duplicate = await guard.check_and_record(event)
+    if duplicate is not None:
+        return WebhookResponse(**duplicate)
+
     event_type = event.get("type", "")
 
     if event_type == "customer.subscription.created":
@@ -34,14 +41,17 @@ async def stripe_webhook(
 
         if not stripe_customer_id:
             logger.warning("No customer ID in subscription event")
+            await guard.record_event(event, status="skipped")
             return WebhookResponse(status="ignored", message="No customer ID")
 
         if not await is_first_subscription(stripe_customer_id, event):
+            await guard.record_event(event, status="skipped")
             return WebhookResponse(status="ignored", message="Not a first subscription")
 
         customer = await get_customer_by_stripe_id(db, stripe_customer_id)
         if customer is None:
             logger.warning(f"Customer not found in DB: {stripe_customer_id}")
+            await guard.record_event(event, status="failed")
             return WebhookResponse(status="error", message="Customer not found")
 
         email_sent = await send_welcome_email(
@@ -50,7 +60,11 @@ async def stripe_webhook(
         )
 
         if email_sent:
+            await guard.record_event(event, status="processed")
             return WebhookResponse(status="processed", message="Welcome email sent")
+
+        await guard.record_event(event, status="failed")
         return WebhookResponse(status="error", message="Failed to send email")
 
+    await guard.record_event(event, status="skipped")
     return WebhookResponse(status="ignored", message=f"Unhandled event type: {event_type}")

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -14,6 +14,7 @@ async def get_db():
 async def init_db():
     from app.models.customer import Base
     import app.models.dead_letter  # noqa: F401 — register DeadLetter with Base.metadata
+    import app.models.webhook_event  # noqa: F401 — register WebhookEvent table
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 

--- a/app/middleware/idempotency.py
+++ b/app/middleware/idempotency.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,6 +16,12 @@ class IdempotencyGuard:
     Uses the webhook_events table to track processed event IDs. Handles
     concurrent duplicate deliveries safely via unique constraint on
     stripe_event_id.
+
+    The guard uses an atomic INSERT approach: it inserts a row with status
+    'pending' when an event is first seen. If a concurrent request tries
+    to insert the same event_id, the unique constraint raises an
+    IntegrityError, which is caught and treated as a duplicate. This
+    eliminates the race window that exists in a SELECT-then-INSERT pattern.
     """
 
     def __init__(self, db: AsyncSession):
@@ -24,7 +30,12 @@ class IdempotencyGuard:
     async def check_and_record(
         self, event: dict[str, Any]
     ) -> dict[str, Any] | None:
-        """Check if an event has already been processed and record it if not.
+        """Atomically claim an event for processing.
+
+        Attempts to INSERT a 'pending' row for the event. If the insert
+        succeeds, the caller owns the event and should process it. If it
+        fails due to a unique constraint violation, the event was already
+        claimed by another request.
 
         Args:
             event: The parsed Stripe event dictionary.
@@ -41,16 +52,21 @@ class IdempotencyGuard:
             logger.warning("Webhook event missing 'id' field, skipping idempotency check")
             return None
 
-        stmt = select(WebhookEvent).where(WebhookEvent.stripe_event_id == event_id)
-        result = await self.db.execute(stmt)
-        existing = result.scalar_one_or_none()
+        webhook_event = WebhookEvent(
+            stripe_event_id=event_id,
+            event_type=event_type,
+            status="pending",
+        )
 
-        if existing is not None:
+        try:
+            self.db.add(webhook_event)
+            await self.db.flush()
+        except IntegrityError:
+            await self.db.rollback()
             logger.info(
-                "Duplicate webhook event %s (type=%s, status=%s), skipping",
+                "Duplicate webhook event %s (type=%s), skipping",
                 event_id,
                 event_type,
-                existing.status,
             )
             return {
                 "status": "skipped",
@@ -62,30 +78,30 @@ class IdempotencyGuard:
     async def record_event(
         self, event: dict[str, Any], status: str = "processed"
     ) -> None:
-        """Record a webhook event as processed.
+        """Update the status of a previously claimed event.
+
+        Called after processing to set the final status (processed/skipped/failed).
 
         Args:
             event: The parsed Stripe event dictionary.
             status: The processing status (processed/skipped/failed).
         """
         event_id = event.get("id")
-        event_type = event.get("type", "unknown")
 
         if not event_id:
             return
 
-        webhook_event = WebhookEvent(
-            stripe_event_id=event_id,
-            event_type=event_type,
-            status=status,
+        stmt = (
+            update(WebhookEvent)
+            .where(WebhookEvent.stripe_event_id == event_id)
+            .values(status=status)
         )
 
         try:
-            self.db.add(webhook_event)
+            await self.db.execute(stmt)
             await self.db.commit()
-        except IntegrityError:
-            # Another concurrent request already recorded this event
+        except Exception:
             await self.db.rollback()
-            logger.info(
-                "Event %s was concurrently recorded by another request", event_id
+            logger.exception(
+                "Failed to update status for event %s", event_id
             )

--- a/app/middleware/idempotency.py
+++ b/app/middleware/idempotency.py
@@ -1,0 +1,91 @@
+import logging
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.webhook_event import WebhookEvent
+
+logger = logging.getLogger(__name__)
+
+
+class IdempotencyGuard:
+    """Guards against duplicate processing of Stripe webhook events.
+
+    Uses the webhook_events table to track processed event IDs. Handles
+    concurrent duplicate deliveries safely via unique constraint on
+    stripe_event_id.
+    """
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def check_and_record(
+        self, event: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Check if an event has already been processed and record it if not.
+
+        Args:
+            event: The parsed Stripe event dictionary.
+
+        Returns:
+            A dict with status/message if the event was already processed
+            (caller should return this as the response), or None if the
+            event is new and should be processed.
+        """
+        event_id = event.get("id")
+        event_type = event.get("type", "unknown")
+
+        if not event_id:
+            logger.warning("Webhook event missing 'id' field, skipping idempotency check")
+            return None
+
+        stmt = select(WebhookEvent).where(WebhookEvent.stripe_event_id == event_id)
+        result = await self.db.execute(stmt)
+        existing = result.scalar_one_or_none()
+
+        if existing is not None:
+            logger.info(
+                "Duplicate webhook event %s (type=%s, status=%s), skipping",
+                event_id,
+                event_type,
+                existing.status,
+            )
+            return {
+                "status": "skipped",
+                "message": f"Event {event_id} already processed",
+            }
+
+        return None
+
+    async def record_event(
+        self, event: dict[str, Any], status: str = "processed"
+    ) -> None:
+        """Record a webhook event as processed.
+
+        Args:
+            event: The parsed Stripe event dictionary.
+            status: The processing status (processed/skipped/failed).
+        """
+        event_id = event.get("id")
+        event_type = event.get("type", "unknown")
+
+        if not event_id:
+            return
+
+        webhook_event = WebhookEvent(
+            stripe_event_id=event_id,
+            event_type=event_type,
+            status=status,
+        )
+
+        try:
+            self.db.add(webhook_event)
+            await self.db.commit()
+        except IntegrityError:
+            # Another concurrent request already recorded this event
+            await self.db.rollback()
+            logger.info(
+                "Event %s was concurrently recorded by another request", event_id
+            )

--- a/app/models/webhook_event.py
+++ b/app/models/webhook_event.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.customer import Base
+
+
+class WebhookEvent(Base):
+    __tablename__ = "webhook_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    stripe_event_id: Mapped[str] = mapped_column(
+        String(255), unique=True, index=True, nullable=False
+    )
+    event_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="processed")
+    processed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )


### PR DESCRIPTION
## Summary
- Adds an idempotency layer to prevent duplicate processing of Stripe webhook events
- Stores processed event IDs in a `webhook_events` database table and rejects duplicates
- Handles concurrent duplicate deliveries safely via unique constraint

Closes #7

## Changes
- **WebhookEvent** SQLAlchemy model for tracking processed events (`app/models/webhook_event.py`)
- **IdempotencyGuard** service with check-and-record pattern (`app/middleware/idempotency.py`)
- Integrated guard into webhook endpoint (`app/api/webhooks.py`)
- Database init updated to create `webhook_events` table (`app/db/database.py`)

## Test plan
- [ ] Verify first webhook event is processed normally
- [ ] Verify duplicate event ID returns "skipped" response
- [ ] Verify concurrent duplicate requests are handled without errors
- [ ] Verify events without an ID field bypass the guard gracefully