### PR TITLE
feat: Email Delivery Retry with Exponential Backoff (INFRA-0003)

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -13,6 +13,7 @@ async def get_db():
 
 async def init_db():
     from app.models.customer import Base
+    import app.models.dead_letter  # noqa: F401 — register DeadLetter with Base.metadata
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 

--- a/app/models/dead_letter.py
+++ b/app/models/dead_letter.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, JSON, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.customer import Base
+
+
+class DeadLetter(Base):
+    __tablename__ = "dead_letter_emails"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    recipient_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    template_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    payload: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    attempts: Mapped[int] = mapped_column(Integer, default=0)
+    first_failed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    last_failed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    status: Mapped[str] = mapped_column(String(50), default="pending")

--- a/app/models/dead_letter.py
+++ b/app/models/dead_letter.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, Integer, JSON, String, Text, func
+from sqlalchemy import DateTime, Index, Integer, JSON, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.customer import Base
@@ -21,4 +21,8 @@ class DeadLetter(Base):
     last_failed_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
-    status: Mapped[str] = mapped_column(String(50), default="pending")
+    status: Mapped[str] = mapped_column(String(50), default="pending", index=True)
+
+    __table_args__ = (
+        Index("ix_dead_letter_emails_recipient", "recipient_email"),
+    )

--- a/app/services/brevo_service.py
+++ b/app/services/brevo_service.py
@@ -3,10 +3,32 @@ import logging
 import httpx
 
 from app.config import settings
+from app.services.retry_service import RetryConfig, with_retry
 
 logger = logging.getLogger(__name__)
 
 BREVO_API_URL = "https://api.brevo.com/v3/smtp/email"
+
+# Retry configuration for Brevo API calls
+_retry_config = RetryConfig(max_retries=3, base_delay=1.0, max_delay=30.0, jitter=True)
+
+
+async def _send_email_request(payload: dict, headers: dict) -> bool:
+    """Execute a single Brevo API request.
+
+    Raises on transient errors so the retry wrapper can handle them.
+    Permanent errors (4xx except 429) also raise but are classified
+    as non-transient by the retry service.
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            BREVO_API_URL, json=payload, headers=headers, timeout=30.0
+        )
+        if response.status_code in (200, 201):
+            return True
+        # Raise an HTTPStatusError so retry_service can inspect the status code
+        response.raise_for_status()
+    return False  # pragma: no cover
 
 
 async def send_welcome_email(to_email: str, customer_name: str) -> bool:
@@ -27,17 +49,23 @@ async def send_welcome_email(to_email: str, customer_name: str) -> bool:
         "Accept": "application/json",
     }
 
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(BREVO_API_URL, json=payload, headers=headers, timeout=30.0)
-            if response.status_code in (200, 201):
-                logger.info(f"Welcome email sent to {to_email}")
-                return True
-            logger.error(f"Brevo API error: {response.status_code} - {response.text}")
-            return False
-    except httpx.HTTPError as e:
-        logger.error(f"Failed to send email via Brevo: {e}")
-        return False
+    logger.info("Sending welcome email to %s (with retry)", to_email)
+    result = await with_retry(
+        _send_email_request,
+        payload,
+        headers,
+        config=_retry_config,
+        recipient_email=to_email,
+        template_id="welcome",
+        payload=payload,
+    )
+
+    if result is True:
+        logger.info("Welcome email sent to %s", to_email)
+        return True
+
+    logger.error("Welcome email delivery failed permanently for %s", to_email)
+    return False
 
 
 def _build_welcome_html(customer_name: str) -> str:

--- a/app/services/brevo_service.py
+++ b/app/services/brevo_service.py
@@ -13,14 +13,17 @@ BREVO_API_URL = "https://api.brevo.com/v3/smtp/email"
 _retry_config = RetryConfig(max_retries=3, base_delay=1.0, max_delay=30.0, jitter=True)
 
 
-async def _send_email_request(payload: dict, headers: dict) -> bool:
+async def _send_email_request(payload: dict, headers: dict, client: httpx.AsyncClient | None = None) -> bool:
     """Execute a single Brevo API request.
 
     Raises on transient errors so the retry wrapper can handle them.
     Permanent errors (4xx except 429) also raise but are classified
     as non-transient by the retry service.
     """
-    async with httpx.AsyncClient() as client:
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient()
+    try:
         response = await client.post(
             BREVO_API_URL, json=payload, headers=headers, timeout=30.0
         )
@@ -28,6 +31,9 @@ async def _send_email_request(payload: dict, headers: dict) -> bool:
             return True
         # Raise an HTTPStatusError so retry_service can inspect the status code
         response.raise_for_status()
+    finally:
+        if owns_client:
+            await client.aclose()
     return False  # pragma: no cover
 
 
@@ -50,15 +56,17 @@ async def send_welcome_email(to_email: str, customer_name: str) -> bool:
     }
 
     logger.info("Sending welcome email to %s (with retry)", to_email)
-    result = await with_retry(
-        _send_email_request,
-        payload,
-        headers,
-        config=_retry_config,
-        recipient_email=to_email,
-        template_id="welcome",
-        payload=payload,
-    )
+    async with httpx.AsyncClient() as client:
+        result = await with_retry(
+            _send_email_request,
+            payload,
+            headers,
+            client,
+            config=_retry_config,
+            recipient_email=to_email,
+            template_id="welcome",
+            payload=payload,
+        )
 
     if result is True:
         logger.info("Welcome email sent to %s", to_email)

--- a/app/services/retry_service.py
+++ b/app/services/retry_service.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import random
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 import httpx
@@ -153,12 +153,18 @@ async def with_retry(
                 )
 
     # Permanent failure — record to dead letter table
+    actual_attempts = attempt + 1 if last_exception is not None else 1
+    error_msg = str(last_exception) if last_exception else "Unknown error"
+    # Truncate error message to avoid storing excessive internal details (S-1)
+    if len(error_msg) > 1000:
+        error_msg = error_msg[:1000] + "... [truncated]"
+
     await _record_dead_letter(
         recipient_email=recipient_email,
         template_id=template_id,
         payload=payload,
-        error_message=str(last_exception),
-        attempts=(config.max_retries + 1) if first_failed_at else 1,
+        error_message=error_msg,
+        attempts=actual_attempts,
         first_failed_at=first_failed_at or datetime.now(timezone.utc),
     )
     return False

--- a/app/services/retry_service.py
+++ b/app/services/retry_service.py
@@ -1,0 +1,164 @@
+import asyncio
+import logging
+import random
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+import httpx
+
+from app.db.database import async_session
+from app.models.dead_letter import DeadLetter
+
+logger = logging.getLogger(__name__)
+
+# HTTP status codes considered transient (eligible for retry)
+TRANSIENT_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+@dataclass
+class RetryConfig:
+    """Configuration for retry behaviour with exponential backoff."""
+
+    max_retries: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 30.0
+    jitter: bool = True
+
+
+def _is_transient_error(exc: Exception) -> bool:
+    """Determine whether an exception represents a transient failure.
+
+    Transient failures are retryable: rate limits (429), server errors (5xx),
+    network timeouts, and connection errors.  Permanent failures (4xx auth/
+    validation errors) should not be retried.
+    """
+    if isinstance(exc, httpx.TimeoutException):
+        return True
+    if isinstance(exc, (httpx.ConnectError, httpx.NetworkError)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in TRANSIENT_STATUS_CODES
+    return False
+
+
+def _compute_delay(attempt: int, config: RetryConfig) -> float:
+    """Compute the backoff delay for a given attempt number.
+
+    Uses exponential backoff capped at *max_delay*, with optional random
+    jitter to prevent thundering-herd effects.
+    """
+    delay = min(config.base_delay * (2 ** attempt), config.max_delay)
+    if config.jitter:
+        delay = delay * (0.5 + random.random())  # jitter between 50-150% of delay
+    return delay
+
+
+async def _record_dead_letter(
+    recipient_email: str,
+    template_id: str | None,
+    payload: dict | None,
+    error_message: str,
+    attempts: int,
+    first_failed_at: datetime,
+) -> None:
+    """Persist a permanently-failed email to the dead_letter_emails table."""
+    try:
+        async with async_session() as session:
+            dead_letter = DeadLetter(
+                recipient_email=recipient_email,
+                template_id=template_id,
+                payload=payload,
+                error_message=error_message,
+                attempts=attempts,
+                first_failed_at=first_failed_at,
+                last_failed_at=datetime.now(timezone.utc),
+                status="pending",
+            )
+            session.add(dead_letter)
+            await session.commit()
+            logger.info(
+                "Recorded dead letter for %s after %d attempt(s)",
+                recipient_email,
+                attempts,
+            )
+    except Exception:
+        logger.exception("Failed to record dead letter for %s", recipient_email)
+
+
+async def with_retry(
+    func,
+    *args,
+    config: RetryConfig | None = None,
+    recipient_email: str = "",
+    template_id: str | None = None,
+    payload: dict | None = None,
+    **kwargs,
+):
+    """Execute *func* with exponential-backoff retries.
+
+    On transient failures the call is retried up to ``config.max_retries``
+    times.  On permanent failure (or after exhausting retries) the email
+    details are written to the dead-letter table and ``False`` is returned.
+
+    Parameters
+    ----------
+    func:
+        The async callable to invoke.
+    config:
+        Retry configuration.  Uses sensible defaults when ``None``.
+    recipient_email, template_id, payload:
+        Metadata persisted to the dead-letter table on permanent failure.
+    """
+    if config is None:
+        config = RetryConfig()
+
+    first_failed_at: datetime | None = None
+    last_exception: Exception | None = None
+
+    for attempt in range(config.max_retries + 1):
+        try:
+            result = await func(*args, **kwargs)
+            return result
+        except Exception as exc:
+            last_exception = exc
+            if first_failed_at is None:
+                first_failed_at = datetime.now(timezone.utc)
+
+            if not _is_transient_error(exc):
+                logger.error(
+                    "Permanent failure on attempt %d for %s: %s",
+                    attempt + 1,
+                    recipient_email,
+                    exc,
+                )
+                break
+
+            if attempt < config.max_retries:
+                delay = _compute_delay(attempt, config)
+                logger.warning(
+                    "Transient failure on attempt %d/%d for %s: %s — retrying in %.2fs",
+                    attempt + 1,
+                    config.max_retries + 1,
+                    recipient_email,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+            else:
+                logger.error(
+                    "All %d retries exhausted for %s: %s",
+                    config.max_retries + 1,
+                    recipient_email,
+                    exc,
+                )
+
+    # Permanent failure — record to dead letter table
+    await _record_dead_letter(
+        recipient_email=recipient_email,
+        template_id=template_id,
+        payload=payload,
+        error_message=str(last_exception),
+        attempts=(config.max_retries + 1) if first_failed_at else 1,
+        first_failed_at=first_failed_at or datetime.now(timezone.utc),
+    )
+    return False


### PR DESCRIPTION
## Summary
- Adds retry mechanism with exponential backoff and jitter for failed Brevo API calls
- Permanently failed emails are stored in a dead_letter_emails table for manual review
- Transient errors (429, 5xx, network/timeout) are retried; permanent errors (4xx auth) fail immediately

Closes #8

## Changes
- **CREATE** `app/models/dead_letter.py` — DeadLetter SQLAlchemy model for failed email persistence
- **CREATE** `app/services/retry_service.py` — RetryConfig dataclass + `with_retry()` orchestrator with exponential backoff
- **MODIFY** `app/services/brevo_service.py` — Wrapped email sending with retry logic, transient vs permanent error classification
- **MODIFY** `app/db/database.py` — Import dead_letter model so table is created on init

## Test plan
- [ ] Verify syntax passes (`python3 -c "import ast; ..."`)
- [ ] Confirm dead_letter_emails table is created on DB init
- [ ] Test transient error retry (mock 429/5xx responses)
- [ ] Test permanent error bypass (mock 401/403 responses)
- [ ] Verify dead letter record created after max retries exhausted