### PR TITLE
feat: Implement database table retention/TTL policy (RPAT-0002)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,13 @@ class Settings(BaseSettings):
     ADMIN_API_KEY: str = ""
     DATABASE_URL: str = "postgresql+asyncpg://localhost:5432/mail_gateway"
 
+    # Retention / TTL policy
+    WEBHOOK_EVENTS_TTL_DAYS: int = 30
+    DEAD_LETTER_TTL_DAYS: int = 90
+    RETENTION_CLEANUP_INTERVAL_HOURS: int = 24
+    RETENTION_BATCH_SIZE: int = 1000
+    RETENTION_HARD_DELETE: bool = True
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -16,7 +16,6 @@ class Settings(BaseSettings):
     DEAD_LETTER_TTL_DAYS: int = 90
     RETENTION_CLEANUP_INTERVAL_HOURS: int = 24
     RETENTION_BATCH_SIZE: int = 1000
-    RETENTION_HARD_DELETE: bool = True
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -6,12 +8,28 @@ from app.api.admin import router as admin_router
 from app.api.webhooks import router as webhooks_router
 from app.config import settings
 from app.db.database import close_db, init_db
+from app.services.retention_service import retention_loop
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
+
+    # Start background retention/TTL cleanup task
+    retention_task = asyncio.create_task(retention_loop())
+    logger.info("Retention background task started")
+
     yield
+
+    # Gracefully cancel the retention task on shutdown
+    retention_task.cancel()
+    try:
+        await retention_task
+    except asyncio.CancelledError:
+        logger.info("Retention background task stopped")
+
     await close_db()
 
 

--- a/app/models/dead_letter.py
+++ b/app/models/dead_letter.py
@@ -25,4 +25,5 @@ class DeadLetter(Base):
 
     __table_args__ = (
         Index("ix_dead_letter_emails_recipient", "recipient_email"),
+        Index("ix_dead_letter_emails_first_failed_at", "first_failed_at"),
     )

--- a/app/models/webhook_event.py
+++ b/app/models/webhook_event.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy import DateTime, Index, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.customer import Base
@@ -17,4 +17,8 @@ class WebhookEvent(Base):
     status: Mapped[str] = mapped_column(String(50), nullable=False, default="processed")
     processed_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index("ix_webhook_events_processed_at", "processed_at"),
     )

--- a/app/services/retention_service.py
+++ b/app/services/retention_service.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, select
 
 from app.config import settings
 from app.db.database import async_session
@@ -16,6 +16,23 @@ from app.models.dead_letter import DeadLetter
 from app.models.webhook_event import WebhookEvent
 
 logger = logging.getLogger(__name__)
+
+# Minimum TTL in days to prevent accidental deletion of all rows
+_MIN_TTL_DAYS = 1
+
+
+def _validate_ttl(ttl_days: int, table_name: str) -> bool:
+    """Return True if the TTL value is safe, False otherwise."""
+    if ttl_days < _MIN_TTL_DAYS:
+        logger.warning(
+            "Retention: %s TTL=%d days is below minimum (%d). "
+            "Skipping cleanup to prevent accidental data loss.",
+            table_name,
+            ttl_days,
+            _MIN_TTL_DAYS,
+        )
+        return False
+    return True
 
 
 async def cleanup_webhook_events(batch_size: int | None = None) -> int:
@@ -25,6 +42,8 @@ async def cleanup_webhook_events(batch_size: int | None = None) -> int:
     contention.  Returns the total number of rows deleted.
     """
     ttl_days = settings.WEBHOOK_EVENTS_TTL_DAYS
+    if not _validate_ttl(ttl_days, "webhook_events"):
+        return 0
     batch = batch_size or settings.RETENTION_BATCH_SIZE
     cutoff = datetime.now(timezone.utc) - timedelta(days=ttl_days)
 
@@ -79,6 +98,8 @@ async def cleanup_dead_letters(batch_size: int | None = None) -> int:
     contention.  Returns the total number of rows deleted.
     """
     ttl_days = settings.DEAD_LETTER_TTL_DAYS
+    if not _validate_ttl(ttl_days, "dead_letter_emails"):
+        return 0
     batch = batch_size or settings.RETENTION_BATCH_SIZE
     cutoff = datetime.now(timezone.utc) - timedelta(days=ttl_days)
 

--- a/app/services/retention_service.py
+++ b/app/services/retention_service.py
@@ -1,0 +1,174 @@
+"""Retention / TTL cleanup service for webhook_events and dead_letter_emails tables.
+
+Runs as an asyncio background task, periodically deleting rows older than the
+configured TTL to prevent unbounded table growth.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete, func, select
+
+from app.config import settings
+from app.db.database import async_session
+from app.models.dead_letter import DeadLetter
+from app.models.webhook_event import WebhookEvent
+
+logger = logging.getLogger(__name__)
+
+
+async def cleanup_webhook_events(batch_size: int | None = None) -> int:
+    """Delete webhook_events rows older than WEBHOOK_EVENTS_TTL_DAYS.
+
+    Deletes in batches to avoid long-running transactions and excessive lock
+    contention.  Returns the total number of rows deleted.
+    """
+    ttl_days = settings.WEBHOOK_EVENTS_TTL_DAYS
+    batch = batch_size or settings.RETENTION_BATCH_SIZE
+    cutoff = datetime.now(timezone.utc) - timedelta(days=ttl_days)
+
+    total_deleted = 0
+
+    async with async_session() as session:
+        while True:
+            # Find IDs of rows past the cutoff in a bounded batch
+            subq = (
+                select(WebhookEvent.id)
+                .where(WebhookEvent.processed_at < cutoff)
+                .limit(batch)
+            )
+            result = await session.execute(subq)
+            ids = [row[0] for row in result.all()]
+
+            if not ids:
+                break
+
+            stmt = delete(WebhookEvent).where(WebhookEvent.id.in_(ids))
+            delete_result = await session.execute(stmt)
+            await session.commit()
+
+            deleted_count = delete_result.rowcount  # type: ignore[union-attr]
+            total_deleted += deleted_count
+            logger.info(
+                "Retention: deleted %d webhook_events (batch), total so far: %d",
+                deleted_count,
+                total_deleted,
+            )
+
+            # If the batch was not full, there are no more rows to delete
+            if len(ids) < batch:
+                break
+
+    if total_deleted > 0:
+        logger.info(
+            "Retention: finished webhook_events cleanup — %d rows deleted (TTL=%d days)",
+            total_deleted,
+            ttl_days,
+        )
+    else:
+        logger.debug("Retention: no webhook_events rows older than %d days", ttl_days)
+
+    return total_deleted
+
+
+async def cleanup_dead_letters(batch_size: int | None = None) -> int:
+    """Delete dead_letter_emails rows older than DEAD_LETTER_TTL_DAYS.
+
+    Deletes in batches to avoid long-running transactions and excessive lock
+    contention.  Returns the total number of rows deleted.
+    """
+    ttl_days = settings.DEAD_LETTER_TTL_DAYS
+    batch = batch_size or settings.RETENTION_BATCH_SIZE
+    cutoff = datetime.now(timezone.utc) - timedelta(days=ttl_days)
+
+    total_deleted = 0
+
+    async with async_session() as session:
+        while True:
+            subq = (
+                select(DeadLetter.id)
+                .where(DeadLetter.first_failed_at < cutoff)
+                .limit(batch)
+            )
+            result = await session.execute(subq)
+            ids = [row[0] for row in result.all()]
+
+            if not ids:
+                break
+
+            stmt = delete(DeadLetter).where(DeadLetter.id.in_(ids))
+            delete_result = await session.execute(stmt)
+            await session.commit()
+
+            deleted_count = delete_result.rowcount  # type: ignore[union-attr]
+            total_deleted += deleted_count
+            logger.info(
+                "Retention: deleted %d dead_letter_emails (batch), total so far: %d",
+                deleted_count,
+                total_deleted,
+            )
+
+            if len(ids) < batch:
+                break
+
+    if total_deleted > 0:
+        logger.info(
+            "Retention: finished dead_letter_emails cleanup — %d rows deleted (TTL=%d days)",
+            total_deleted,
+            ttl_days,
+        )
+    else:
+        logger.debug(
+            "Retention: no dead_letter_emails rows older than %d days", ttl_days
+        )
+
+    return total_deleted
+
+
+async def run_cleanup() -> dict[str, int]:
+    """Execute a single cleanup cycle for all managed tables.
+
+    Returns a summary dict with the count of deleted rows per table.
+    """
+    logger.info("Retention: starting cleanup cycle")
+    results: dict[str, int] = {}
+
+    try:
+        results["webhook_events"] = await cleanup_webhook_events()
+    except Exception:
+        logger.exception("Retention: error cleaning up webhook_events")
+        results["webhook_events"] = -1
+
+    try:
+        results["dead_letter_emails"] = await cleanup_dead_letters()
+    except Exception:
+        logger.exception("Retention: error cleaning up dead_letter_emails")
+        results["dead_letter_emails"] = -1
+
+    logger.info("Retention: cleanup cycle complete — %s", results)
+    return results
+
+
+async def retention_loop() -> None:
+    """Long-running background loop that triggers periodic cleanup.
+
+    Designed to be launched via ``asyncio.create_task()`` during application
+    startup.  Runs indefinitely until the task is cancelled.
+    """
+    interval_seconds = settings.RETENTION_CLEANUP_INTERVAL_HOURS * 3600
+    logger.info(
+        "Retention: background loop started (interval=%dh, webhook_events TTL=%dd, "
+        "dead_letter TTL=%dd)",
+        settings.RETENTION_CLEANUP_INTERVAL_HOURS,
+        settings.WEBHOOK_EVENTS_TTL_DAYS,
+        settings.DEAD_LETTER_TTL_DAYS,
+    )
+
+    while True:
+        try:
+            await run_cleanup()
+        except Exception:
+            logger.exception("Retention: unexpected error in cleanup cycle")
+
+        await asyncio.sleep(interval_seconds)


### PR DESCRIPTION
## Summary
- Added `retention_service.py` with batched cleanup for `webhook_events` (30-day default TTL) and `dead_letter_emails` (90-day default TTL) tables
- Configurable via environment variables: `WEBHOOK_EVENTS_TTL_DAYS`, `DEAD_LETTER_TTL_DAYS`, `RETENTION_CLEANUP_INTERVAL_HOURS`, `RETENTION_BATCH_SIZE`
- Background asyncio task registered in FastAPI lifespan with graceful shutdown
- Added database indexes on `processed_at` (webhook_events) and `first_failed_at` (dead_letter_emails) for efficient cleanup queries

Closes #19

## Test plan
- [ ] Verify the application starts without errors and the retention loop logs its startup
- [ ] Set short TTL values (e.g., 0 days) and insert test rows to confirm cleanup deletes expired records
- [ ] Confirm batch deletion works correctly when row count exceeds `RETENTION_BATCH_SIZE`
- [ ] Verify graceful shutdown cancels the background task without errors
- [ ] Check that new indexes are created on the database tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)